### PR TITLE
Edit Descrition in config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,9 +16,8 @@
 title: Self Taught Programmers
 email: 
 description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  This is site created by programmers who taught themselves to code FOR programmers who taught themselves to code.
+  You can share your projects here, and meet other coders who have similar interests to yours. 
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "selftaughtprogrammers.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: 


### PR DESCRIPTION
Changed the description from default to custom about the purpose of the site.

This will give us a little more exposure and provide an incentive for people who are interested in finding the group to visit.